### PR TITLE
(RST-7796) Upgrade Traefik to v2.11.32

### DIFF
--- a/compose.development.yaml
+++ b/compose.development.yaml
@@ -11,7 +11,7 @@ version: "3.8"
 services:
   traefik:
     # The official v2 Traefik docker image
-    image: traefik:v2.5
+    image: traefik:v2.11.32
     # Enables the web UI and tells Traefik to listen to docker
     command: --api.insecure=true --providers.docker --entryPoints.http.address=:3100 --entryPoints.traefik.address=:3200 --ping
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,7 +11,7 @@ version: "3.8"
 services:
   traefik:
     # The official v2 Traefik docker image
-    image: traefik:v2.5
+    image: traefik:v2.11.32
     command:
       - --api.insecure=true
       - --providers.docker


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [RST-7796](https://tools.hmcts.net/jira/browse/RST-7796)

### Change description

The Traefik version in use (v2.5) depends on the Docker API v1.24, which is no longer supported by newer releases of Docker (v29+).

Upgrading to Traefik to v2.11.32 fixes these issues, with the Docker API version no longer hardcoded.

### Testing done

Performed regression tests.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->
